### PR TITLE
RELENG-5833 avoid 408 hopefully

### DIFF
--- a/conf/nginx.conf.template
+++ b/conf/nginx.conf.template
@@ -175,6 +175,11 @@ http {
     proxy_send_timeout 600s;
     proxy_connect_timeout 600s;
 
+    # This will help to prevent returning a 408 status.
+    #
+    client_header_timeout 600s;
+    client_body_timeout 600s;
+
     # Handle status module.
     #
     location /nginx_status {


### PR DESCRIPTION
Those settings are said to control the fact that an nginx service may answer a 408 status:
http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_timeout