### PR TITLE
RELENG-7477: changed the apiversion of ingress

### DIFF
--- a/charts/artifacts/templates/ingress.yaml
+++ b/charts/artifacts/templates/ingress.yaml
@@ -16,7 +16,7 @@ data:
   auth: {{ list .basicAuth.username .basicAuth.passwordHash | join ":" | b64enc | quote }}
 {{- end }}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "fullname" $ }}


### PR DESCRIPTION
The ingress resource used by artifacts used the old endpoint. This is no longer valid in the new versions of kubernetes