### PR TITLE
RELENG-7477: artifacts ingress resource

### DIFF
--- a/charts/artifacts/templates/ingress.yaml
+++ b/charts/artifacts/templates/ingress.yaml
@@ -41,8 +41,10 @@ spec:
       paths:
         - path: {{ .path | quote }}
           backend:
-            serviceName: {{ template "fullname" $ }}
-            servicePort: {{ $.Values.deployment.service.port }}
+            service:
+              name: {{ template "fullname" $ }}
+              port:
+                number: {{ $.Values.deployment.service.port }}
   {{- if .tls }}
   tls:
   - hosts:


### PR DESCRIPTION
The apiversion changed also means some of the parameters are no longer valid. This PR changes it to the right parameters. This was an omission on my part.