### PR TITLE
Making liveness and readiness probes configurable

### DIFF
--- a/charts/artifacts/templates/deployment.yaml
+++ b/charts/artifacts/templates/deployment.yaml
@@ -46,20 +46,12 @@ spec:
           httpGet:
             path: /_healthz
             port: http
-          initialDelaySeconds: 5
-          periodSeconds: 5
-          timeoutSeconds: 5
-          successThreshold: 1
-          failureThreshold: 3
+{{ toYaml .Values.deployment.artifacts.readinessProbe | indent 10 }}
         livenessProbe:
           httpGet:
             path: /_healthz
             port: http
-          initialDelaySeconds: 5
-          periodSeconds: 60
-          timeoutSeconds: 5
-          successThreshold: 1
-          failureThreshold: 3
+{{ toYaml .Values.deployment.artifacts.livenessProbe | indent 10 }}
       volumes:
       - name: cache
         emptyDir: {}

--- a/charts/artifacts/values.yaml
+++ b/charts/artifacts/values.yaml
@@ -96,6 +96,22 @@ deployment:
         cpu: "2"
         memory: "2Gi"
 
+    ## Configure the liveness probe to check if the pod is still running.
+    livenessProbe:
+      initialDelaySeconds: 10
+      periodSeconds: 30
+      timeoutSeconds: 5
+      successThreshold: 1
+      failureThreshold: 5
+
+    ## Configure the readiness probe to check if the pod is ready to serve traffic.
+    readinessProbe:
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      timeoutSeconds: 5
+      successThreshold: 1
+      failureThreshold: 3
+
   ## Configure the ingress resource that allows you to access the service.
   ingress:
     ## enabled sets the ingress record generation or not.


### PR DESCRIPTION
Currently set in the development environment only
