### PR TITLE
Add lifecycle hooks for the artifacts deployment

### DIFF
--- a/charts/artifacts/templates/deployment.yaml
+++ b/charts/artifacts/templates/deployment.yaml
@@ -57,6 +57,10 @@ spec:
             path: /_healthz
             port: http
 {{ toYaml .Values.deployment.artifacts.livenessProbe | indent 10 }}
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh","-c","nginx -s quit; while killall -0 nginx; do sleep 1; done"]
       volumes:
       - name: cache
         emptyDir: {}


### PR DESCRIPTION
This configuration includes a `preStop` hook that executes a command to gracefully stop the nginx server before the container is terminated. 
