### PR TITLE
PTFE-1834 check for active connections on prestop

### DIFF
--- a/charts/artifacts/values.yaml
+++ b/charts/artifacts/values.yaml
@@ -186,4 +186,4 @@ deployment:
   ## Affinity for pod assignment
   ##
   affinity: {}
-  terminationGracePeriodSeconds: 300
+  terminationGracePeriodSeconds: 600

--- a/stop.sh
+++ b/stop.sh
@@ -5,6 +5,16 @@ export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 echo "Stopping nginx..."
 # Wait a bit before signaling the process to stop
 sleep 5
+
+# retrieve nginx status and check if there's any active connection
+ACTIVE_CONNECTION=""
+
+while [ ${ACTIVE_CONNECTION} != "1" ]; do
+  ACTIVE_CONNECTION=$(curl -s http://localhost/nginx_status | grep 'Active connections' | awk '{print $3}')
+  echo "Active connections: ${ACTIVE_CONNECTION}"
+  sleep 1
+done
+
 PID=$(cat /run/nginx.pid)
 nginx -s quit
 

--- a/tests/end2end/test_simple.py
+++ b/tests/end2end/test_simple.py
@@ -638,6 +638,19 @@ class TestSimple(unittest.TestCase):
         ), headers={'Script-Name': '/foo'})
         assert 'Location' not in req.headers
 
+    def test_nginx_status(self):
+        # assert "Active connections: 1" in req.text
+        # retry as much as needed in case there is more active connections from other
+        # tests running
+        for _ in range(10):
+            req = self.session.get(f"{self.artifacts_url}/nginx_status")
+            if "Active connections: 1 \n" in req.text:
+                break
+            if _ == 9:
+                assert False, "Active connections: 1 not found in nginx_status"
+            time.sleep(1)
+
+
 
 @pytest.mark.usefixtures("s3_client", "container", "artifacts_url", "buckets")
 class TestExternalBasicAuthentication(unittest.TestCase):


### PR DESCRIPTION
While `nginx -s quit` does a graceful shutdown, it may shutdown (not so gracefully) connections done with `keepalive`. Which is typically the operations seen in promotions.

