### PR TITLE
(PTFE-3070) Fix redirection web ui

### DIFF
--- a/conf/nginx.conf.template
+++ b/conf/nginx.conf.template
@@ -271,7 +271,9 @@ http {
     # Directory listings (trailing slash) always go to /download/.
     # $builds_backend is set by the map directive in the http block above.
     #
-    rewrite ^/builds/([^/]+/.+[^/])$ $builds_backend$1 last;
+    if ($builds_backend = /redirect/) {
+        rewrite ^/builds/([^/]+/.+[^/])$ /redirect/$1 last;
+    }
     rewrite ^/builds/(.*)$ /download/$1 last;
 
     # Handle subdir listing under "/redirect/"

--- a/tests/end2end/test_routing.py
+++ b/tests/end2end/test_routing.py
@@ -86,14 +86,19 @@ def test_builds_cli_ua_redirects_to_presigned_url(upload_file, session, artifact
 
 
 def test_builds_browser_ua_proxied_directly(upload_file, session, artifacts_url):
-    """GET /builds/ with a Mozilla UA is rewritten to /download/ → 200 proxied."""
-    upload_file(STAGING_BUILD, 'file.txt')
+    """GET /builds/ with a Mozilla UA is rewritten to /download/ → 200 proxied.
+
+    The response body must be the file content, not an HTML directory listing.
+    """
+    data = b'browser-proxied content'
+    upload_file(STAGING_BUILD, 'file.txt', data=data)
     resp = session.get(
         f'{artifacts_url}/builds/{STAGING_BUILD}/file.txt',
         headers={'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64)'},
         allow_redirects=False,
     )
     assert resp.status_code == 200
+    assert resp.content == data
 
 
 def test_builds_head_always_proxied_regardless_of_ua(upload_file, session, artifacts_url):


### PR DESCRIPTION
Improvements to URL routing:

* Added an `if` statement to check if `$builds_backend` is `/redirect` and, if so, rewrites build URLs to `/redirect/$1`. This ensures proper handling of builds that require redirection.

Why ? 
* Clicking a file in the web UI redirected to the root build listing instead of serving the file. This affected all browser clients (Mozilla User-Agent) navigating via /builds/. 
*  The rewrite rule introduced in PTFE-3085 used an nginx variable in the replacement string ($builds_backend$1). When $builds_backend resolved to /download/, nginx failed to match the file-download location and fell through to the root listing location instead