### PR TITLE
fix: URL-encode uploadId in canonical resource for GCS V2 presigned part URLs

### DIFF
--- a/lua/compute_aws_s3_signature.lua
+++ b/lua/compute_aws_s3_signature.lua
@@ -373,14 +373,17 @@ elseif signature_mode == "PRESIGN_PART" then
   end
   local expires     = ngx.time() + 3600
   local aws_secret_key = os.getenv('AWS_SECRET_ACCESS_KEY')
+  -- GCS V2 requires URL-encoded values in the canonical resource (unlike AWS V2 which uses raw values).
+  -- See: https://cloud.google.com/storage/docs/access-control/signed-urls-v2
+  local escaped_upload_id = ngx.escape_uri(upload_id)
   -- subresources must appear in canonical resource (alphabetical: partNumber < uploadId)
   local canonicalized_resource = "/" .. ngx.var.aws_tgt_bucket .. "/" .. ngx.var.encoded_key ..
-    "?partNumber=" .. part_number .. "&uploadId=" .. upload_id
+    "?partNumber=" .. part_number .. "&uploadId=" .. escaped_upload_id
   local string_to_sign = "PUT\n\n\n" .. expires .. "\n" .. canonicalized_resource
   local aws_signature = ngx.encode_base64(ngx.hmac_sha1(aws_secret_key, string_to_sign))
   local presigned_url = ngx.var.redirect_endpoint .. "/" .. ngx.var.aws_tgt_bucket .. "/" .. ngx.var.encoded_key ..
     "?partNumber=" .. part_number ..
-    "&uploadId=" .. ngx.escape_uri(upload_id) ..
+    "&uploadId=" .. escaped_upload_id ..
     "&AWSAccessKeyId=" .. ngx.escape_uri(ngx.var.aws_access_key) ..
     "&Expires=" .. expires ..
     "&Signature=" .. ngx.escape_uri(aws_signature)

--- a/lua/compute_aws_s3_signature.lua
+++ b/lua/compute_aws_s3_signature.lua
@@ -375,7 +375,9 @@ elseif signature_mode == "PRESIGN_PART" then
   local aws_secret_key = os.getenv('AWS_SECRET_ACCESS_KEY')
   -- GCS V2 requires URL-encoded values in the canonical resource (unlike AWS V2 which uses raw values).
   -- See: https://cloud.google.com/storage/docs/access-control/signed-urls-v2
-  local escaped_upload_id = ngx.escape_uri(upload_id)
+  -- ngx.var.arg_* may return a raw (already percent-encoded) or decoded value depending on the nginx
+  -- version. Normalize by unescaping first, then re-escaping to avoid double-encoding (%2B → %252B).
+  local escaped_upload_id = ngx.escape_uri(ngx.unescape_uri(upload_id))
   -- subresources must appear in canonical resource (alphabetical: partNumber < uploadId)
   local canonicalized_resource = "/" .. ngx.var.aws_tgt_bucket .. "/" .. ngx.var.encoded_key ..
     "?partNumber=" .. part_number .. "&uploadId=" .. escaped_upload_id

--- a/tests/end2end/test_presign_upload.py
+++ b/tests/end2end/test_presign_upload.py
@@ -92,6 +92,26 @@ def test_presign_upload_part_returns_url(session, artifacts_url):
         )
 
 
+def test_presign_upload_part_encodes_special_chars_in_upload_id(session, artifacts_url):
+    """uploadId containing +, / and = (GCS-style base64) is percent-encoded in the presigned URL."""
+    # Use a synthetic uploadId with base64 special characters. The PRESIGN_PART
+    # endpoint does not validate that the uploadId corresponds to a real upload,
+    # so we can inject one directly to verify the encoding behaviour without
+    # needing a backend that generates such IDs.
+    special_upload_id = 'abc+def/ghi=jkl'
+    resp = session.get(
+        f'{artifacts_url}/presign-upload-part/{STAGING_BUILD}/presign/encoding-test.bin',
+        params={'partNumber': 1, 'uploadId': special_upload_id},
+    )
+    assert resp.status_code == 200, f'{resp.status_code} {resp.text}'
+    url = resp.text.strip()
+    # The uploadId must appear percent-encoded in the presigned URL so that GCS
+    # can reconstruct the canonical resource from the URL literally (GCS V2 spec).
+    assert 'uploadId=abc%2Bdef%2Fghi%3Djkl' in url, (
+        f'Expected uploadId to be percent-encoded in presigned URL, got: {url!r}'
+    )
+
+
 def test_presign_multipart_full_round_trip(session, artifacts_url):
     """Initiate via nginx, upload parts directly to S3, complete via nginx."""
     build = STAGING_BUILD


### PR DESCRIPTION
## Summary

- GCS V2 signing requires the canonical resource to include URL-encoded values **as they appear in the URL** (unlike AWS V2 which uses raw/decoded values)
- Without this fix, uploadIds containing characters like `+`, `/` or `=` (common in GCS base64-encoded IDs) produce a `SignatureDoesNotMatch` (403) when GCS verifies the presigned part PUT
- Fix: use `ngx.escape_uri(upload_id)` in the canonical resource for `PRESIGN_PART` mode, consistent with the value already used in the presigned URL itself

Reference: [GCS V2 Signing Process](https://docs.cloud.google.com/storage/docs/access-control/signed-urls-v2) — *"copy the HTTP request path literally: that is, you should include all URL encoding (percent signs) in the string that you create."*

## Root cause

Observed in production on `scality/scalityos` CI — multipart uploads of large ISO files (50 parts) failed with:
```
SignatureDoesNotMatch: The request signature we calculated does not match
the signature you provided. Check your Google secret key and signing method.
```

## Test plan

- [x] `test_presign_upload.py` — all 7 tests pass (including `test_presign_multipart_full_round_trip`)
- [x] `test_multipart_upload.py` — all 5 tests pass
- [ ] Validate in production by re-running a failing `scalityos` CI job

🤖 Generated with [Claude Code](https://claude.com/claude-code)