### PR TITLE
Fix GCS ':' encoding for proxied multipart complete and abort

### DIFF
--- a/lua/compute_aws_s3_signature.lua
+++ b/lua/compute_aws_s3_signature.lua
@@ -291,16 +291,21 @@ elseif signature_mode == "MULTIPART_UPLOAD_PART" then
   if not part_number or part_number == "" or not upload_id or upload_id == "" then
     return ngx.exit(ngx.HTTP_BAD_REQUEST)
   end
-  -- GCS normalises ':' to '%3A' in canonical resources when S3 subresource params
-  -- (partNumber, uploadId) are present. Apply to both the signature and the proxy URL
-  -- ($encoded_key). Standard backends keep literal ':'.
+  -- GCS does not include partNumber/uploadId in the canonical resource and
+  -- normalises ':' to '%3A' in the key — same quirks as for presigned part PUTs.
+  -- Standard S3-compatible backends include subresources and keep literal ':'.
   if (os.getenv('ENDPOINT_URL') or ''):find('googleapis', 1, true) then
     ngx.var.encoded_key = ngx.var.encoded_key:gsub(':', '%%3A')
+    compute_S3_signature_with_resource(
+      "x-amz-date:" .. ngx.var.x_amz_date,
+      "/" .. ngx.var.aws_tgt_bucket .. "/" .. ngx.var.encoded_key
+    )
+  else
+    compute_S3_signature_with_resource(
+      "x-amz-date:" .. ngx.var.x_amz_date,
+      "/" .. ngx.var.aws_tgt_bucket .. "/" .. ngx.var.encoded_key .. "?partNumber=" .. part_number .. "&uploadId=" .. upload_id
+    )
   end
-  compute_S3_signature_with_resource(
-    "x-amz-date:" .. ngx.var.x_amz_date,
-    "/" .. ngx.var.aws_tgt_bucket .. "/" .. ngx.var.encoded_key .. "?partNumber=" .. part_number .. "&uploadId=" .. upload_id
-  )
 
 elseif signature_mode == "MULTIPART_COMPLETE" then
 
@@ -315,15 +320,21 @@ elseif signature_mode == "MULTIPART_COMPLETE" then
   if not upload_id or upload_id == "" then
     return ngx.exit(ngx.HTTP_BAD_REQUEST)
   end
-  -- GCS normalises ':' to '%3A' in canonical resources when S3 subresource params
-  -- (uploadId) are present. Apply to both the signature and the proxy URL ($encoded_key).
+  -- GCS does not include uploadId in the canonical resource and normalises
+  -- ':' to '%3A' in the key. Standard S3-compatible backends include the
+  -- subresource and keep literal ':'.
   if (os.getenv('ENDPOINT_URL') or ''):find('googleapis', 1, true) then
     ngx.var.encoded_key = ngx.var.encoded_key:gsub(':', '%%3A')
+    compute_S3_signature_with_resource(
+      "x-amz-date:" .. ngx.var.x_amz_date,
+      "/" .. ngx.var.aws_tgt_bucket .. "/" .. ngx.var.encoded_key
+    )
+  else
+    compute_S3_signature_with_resource(
+      "x-amz-date:" .. ngx.var.x_amz_date,
+      "/" .. ngx.var.aws_tgt_bucket .. "/" .. ngx.var.encoded_key .. "?uploadId=" .. upload_id
+    )
   end
-  compute_S3_signature_with_resource(
-    "x-amz-date:" .. ngx.var.x_amz_date,
-    "/" .. ngx.var.aws_tgt_bucket .. "/" .. ngx.var.encoded_key .. "?uploadId=" .. upload_id
-  )
 
 elseif signature_mode == "MULTIPART_ABORT" then
 
@@ -338,15 +349,21 @@ elseif signature_mode == "MULTIPART_ABORT" then
   if not upload_id or upload_id == "" then
     return ngx.exit(ngx.HTTP_BAD_REQUEST)
   end
-  -- GCS normalises ':' to '%3A' in canonical resources when S3 subresource params
-  -- (uploadId) are present. Apply to both the signature and the proxy URL ($encoded_key).
+  -- GCS does not include uploadId in the canonical resource and normalises
+  -- ':' to '%3A' in the key. Standard S3-compatible backends include the
+  -- subresource and keep literal ':'.
   if (os.getenv('ENDPOINT_URL') or ''):find('googleapis', 1, true) then
     ngx.var.encoded_key = ngx.var.encoded_key:gsub(':', '%%3A')
+    compute_S3_signature_with_resource(
+      "x-amz-date:" .. ngx.var.x_amz_date,
+      "/" .. ngx.var.aws_tgt_bucket .. "/" .. ngx.var.encoded_key
+    )
+  else
+    compute_S3_signature_with_resource(
+      "x-amz-date:" .. ngx.var.x_amz_date,
+      "/" .. ngx.var.aws_tgt_bucket .. "/" .. ngx.var.encoded_key .. "?uploadId=" .. upload_id
+    )
   end
-  compute_S3_signature_with_resource(
-    "x-amz-date:" .. ngx.var.x_amz_date,
-    "/" .. ngx.var.aws_tgt_bucket .. "/" .. ngx.var.encoded_key .. "?uploadId=" .. upload_id
-  )
 
 elseif signature_mode == "PRESIGN_PUT" then
 

--- a/lua/compute_aws_s3_signature.lua
+++ b/lua/compute_aws_s3_signature.lua
@@ -291,6 +291,12 @@ elseif signature_mode == "MULTIPART_UPLOAD_PART" then
   if not part_number or part_number == "" or not upload_id or upload_id == "" then
     return ngx.exit(ngx.HTTP_BAD_REQUEST)
   end
+  -- GCS normalises ':' to '%3A' in canonical resources when S3 subresource params
+  -- (partNumber, uploadId) are present. Apply to both the signature and the proxy URL
+  -- ($encoded_key). Standard backends keep literal ':'.
+  if (os.getenv('ENDPOINT_URL') or ''):find('googleapis', 1, true) then
+    ngx.var.encoded_key = ngx.var.encoded_key:gsub(':', '%%3A')
+  end
   compute_S3_signature_with_resource(
     "x-amz-date:" .. ngx.var.x_amz_date,
     "/" .. ngx.var.aws_tgt_bucket .. "/" .. ngx.var.encoded_key .. "?partNumber=" .. part_number .. "&uploadId=" .. upload_id
@@ -309,6 +315,11 @@ elseif signature_mode == "MULTIPART_COMPLETE" then
   if not upload_id or upload_id == "" then
     return ngx.exit(ngx.HTTP_BAD_REQUEST)
   end
+  -- GCS normalises ':' to '%3A' in canonical resources when S3 subresource params
+  -- (uploadId) are present. Apply to both the signature and the proxy URL ($encoded_key).
+  if (os.getenv('ENDPOINT_URL') or ''):find('googleapis', 1, true) then
+    ngx.var.encoded_key = ngx.var.encoded_key:gsub(':', '%%3A')
+  end
   compute_S3_signature_with_resource(
     "x-amz-date:" .. ngx.var.x_amz_date,
     "/" .. ngx.var.aws_tgt_bucket .. "/" .. ngx.var.encoded_key .. "?uploadId=" .. upload_id
@@ -326,6 +337,11 @@ elseif signature_mode == "MULTIPART_ABORT" then
   local upload_id = ngx.var.arg_uploadId
   if not upload_id or upload_id == "" then
     return ngx.exit(ngx.HTTP_BAD_REQUEST)
+  end
+  -- GCS normalises ':' to '%3A' in canonical resources when S3 subresource params
+  -- (uploadId) are present. Apply to both the signature and the proxy URL ($encoded_key).
+  if (os.getenv('ENDPOINT_URL') or ''):find('googleapis', 1, true) then
+    ngx.var.encoded_key = ngx.var.encoded_key:gsub(':', '%%3A')
   end
   compute_S3_signature_with_resource(
     "x-amz-date:" .. ngx.var.x_amz_date,


### PR DESCRIPTION
## Summary

GCS normalises `:` to `%3A` in the canonical resource whenever S3 subresource params (`uploadId`, `partNumber`) are present — not only for presigned URLs (fixed in #218/#219) but also for **Authorization-header proxied requests**.

`MULTIPART_COMPLETE` and `MULTIPART_ABORT` both include `?uploadId=X` in the canonical resource, so GCS rejects them with 403. `MULTIPART_UPLOAD_PART` (proxied part upload) has the same issue.

Pattern:
- `MULTIPART_INITIATE` (`?uploads`) — works, GCS does not normalise for this subresource
- `PRESIGN_PART` (`?partNumber=N&uploadId=X`) — fixed in #219
- `MULTIPART_COMPLETE` / `MULTIPART_ABORT` / `MULTIPART_UPLOAD_PART` (`?uploadId=X`) — **this PR**

**Change:** for GCS backends (`ENDPOINT_URL` contains `googleapis`), encode `:` as `%3A` in `encoded_key` before signing. The `proxy_pass` URL uses `$encoded_key` so the path sent to GCS is updated automatically. Standard S3-compatible backends (cloudserver, Scaleway) keep literal `:`.

## Test plan

- [ ] CI passes (`test.yml` — cloudserver round-trip test exercises complete + abort)
- [ ] New release and devinfra bump; re-run `test-upload` in `scality/action-artifacts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)